### PR TITLE
fix text overlap in quiz card

### DIFF
--- a/src/app/quiz/quiz.component.scss
+++ b/src/app/quiz/quiz.component.scss
@@ -49,6 +49,7 @@
   .definition {
     font-size: 3em;
     line-height: 1em;
+    margin-bottom: 10px;
   }
 }
 


### PR DESCRIPTION
any descenders in the definition text would overlap with the Japanese word below it. the margin gives enough space to make both readable without it looking awkward